### PR TITLE
added project btn disabling feature

### DIFF
--- a/client/src/components/AddProjectModal.jsx
+++ b/client/src/components/AddProjectModal.jsx
@@ -52,6 +52,7 @@ export default function AddProjectModal() {
             className='btn btn-primary'
             data-bs-toggle='modal'
             data-bs-target='#addProjectModal'
+            disabled={data.clients.length < 1 ? 'disabled' : ''}
           >
             <div className='d-flex align-items-center'>
               <FaList className='icon' />

--- a/client/src/components/AddProjectModal.jsx
+++ b/client/src/components/AddProjectModal.jsx
@@ -52,7 +52,7 @@ export default function AddProjectModal() {
             className='btn btn-primary'
             data-bs-toggle='modal'
             data-bs-target='#addProjectModal'
-            disabled={data.clients.length < 1 ? 'disabled' : ''}
+            disabled={data.clients.length === 0}
           >
             <div className='d-flex align-items-center'>
               <FaList className='icon' />


### PR DESCRIPTION
After learning graphQL via your video, I recognized that it will be better to add a certain simple one-line feature:

It is better to prevent adding a project while there is not any client registered. It will be not necessary while we had a feature of projects assignment but not included in the architecture you designed.

**P. S**: I'm learning to use and contribute to open-source projects lol.