### PR TITLE
Redirect to NotFound on incorrect project id

### DIFF
--- a/client/src/pages/Project.jsx
+++ b/client/src/pages/Project.jsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams, useNavigate } from 'react-router-dom';
 import Spinner from '../components/Spinner';
 import ClientInfo from '../components/ClientInfo';
 import DeleteProjectButton from '../components/DeleteProjectButton';
@@ -7,11 +7,12 @@ import { useQuery } from '@apollo/client';
 import { GET_PROJECT } from '../queries/projectQueries';
 
 export default function Project() {
+  const navigate = useNavigate();
   const { id } = useParams();
   const { loading, error, data } = useQuery(GET_PROJECT, { variables: { id } });
 
   if (loading) return <Spinner />;
-  if (error) return <p>Something Went Wrong</p>;
+  if (error) return navigate("/error");
 
   return (
     <>


### PR DESCRIPTION
On wrong project id current version showing "something went wrong message"
Instead of this error message current commit will navigate such requests to "/error" which will ultimately show the 404 not found message page.